### PR TITLE
Docs: fix arguments order for "throttledComputed" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ milliseconds before re-evaluation. It is like a computed version of the standard
 
 ### Parameters
 
-- `delay` - the minimum time in milliseconds to wait before re-evaluating
 - `compute` - the function to evaluate to get a plain value
+- `delay` - the minimum time in milliseconds to wait before re-evaluating
 
 ### Returns
 


### PR DESCRIPTION
The actual API is `throttledComputed(compute, delay)`, apparently it's a typo in docs.