### PR TITLE
Remove path to missing file

### DIFF
--- a/fix-coverage.js
+++ b/fix-coverage.js
@@ -1,13 +1,12 @@
-var fs = require("fs"),    
+var fs = require("fs"),
     prefix = "var __decorate =",
     paths = [
         "built/src/promisedComputed.js",
-        "built/src/deprecatedComputedAsync.js",
     ];
 
 paths.forEach(path => {
 
-    // tell istanbul to ignore TS-generated decorator code 
+    // tell istanbul to ignore TS-generated decorator code
     var src = fs.readFileSync(path, "utf8");
     src = src.replace(prefix, "/* istanbul ignore next */\n" + prefix);
     fs.writeFileSync(path, src);


### PR DESCRIPTION
Fixes `Error: ENOENT: no such file or directory, open 'built/src/deprecatedComputedAsync.js'` since it was removed with latest release.

Sidenote, it seems the Travis and Coveralls checks stopped running with latest commits and only the pages build runs now?

<img width="402" alt="image" src="https://user-images.githubusercontent.com/998924/102100494-c5520480-3e29-11eb-9870-1ea6aba464bc.png">
